### PR TITLE
Ensure buffer is live before making it current

### DIFF
--- a/timeout.el
+++ b/timeout.el
@@ -76,7 +76,9 @@ This is intended for use as function advice."
                  (lambda (buf)
                    (cancel-timer debounce-timer)
                    (setq debounce-timer nil)
-                   (with-current-buffer buf
+                   (if (buffer-live-p buf)
+                       (with-current-buffer buf
+                         (apply orig-fn args))
                      (apply orig-fn args)))
                  (current-buffer))))))))
 


### PR DESCRIPTION
It's possible that between the current buffer is passed to the lambda to the time the lambda is invoked, the buffer has already been killed. If that's the case, attempting to make it current will result in an error. This PR ensures the buffer is live before setting it to the current buffer.