### PR TITLE
timeout: Name advice functions.

### DIFF
--- a/timeout.el
+++ b/timeout.el
@@ -143,7 +143,9 @@ first time.  On future invocations, the result from the previous call is
 returned."
   (if (and delay (eq delay 0))
       (advice-remove func 'debounce)
-    (advice-add func :around (timeout--debounce-advice delay default)
+    (advice-add func :around
+                (defalias (intern (concat "timeout-debounce-on-" (symbol-name func)))
+                  (timeout--debounce-advice delay))
                 '((name . debounce)
                   (depth . -99)))))
 
@@ -160,7 +162,9 @@ When FUNC does not run because of the throttle, the result from the
 previous successful call is returned."
   (if (and throttle (eq throttle 0))
       (advice-remove func 'throttle)
-    (advice-add func :around (timeout--throttle-advice throttle)
+    (advice-add func :around
+                (defalias (intern (concat "timeout-throttle-on-" (symbol-name func)))
+                  (timeout--throttle-advice throttle))
                 '((name . throttle)
                   (depth . -98)))))
 


### PR DESCRIPTION
I believe it is generally considered good practice to use named functions rather than anonymous lambdas for hook-like things, like when adding functions to hook variables or defining advice. Named functions make debugging simpler, as one can readily identify their origin and location.  

With this patch applied, for example, inspecting a function such as `example-func` using `C-h f` immediately shows that it is advised by a `timeout-*` function. The user can then further examine the advice function itself, improving traceability and clarity.  

<img width="621" height="189" alt="Screenshot 2025-09-08 at 13 59 22" src="https://github.com/user-attachments/assets/e6eb72d5-9cb0-478b-84dd-cb17ac994e00" />
<img width="661" height="493" alt="Screenshot 2025-09-08 at 14 00 40" src="https://github.com/user-attachments/assets/82636203-8518-4714-8605-6625c2eacfe9" />
