### PR TITLE
Save timeout state in a struct

### DIFF
--- a/timeout.el
+++ b/timeout.el
@@ -57,9 +57,17 @@
 
 ;;; Code:
 (require 'nadvice)
+(require 'cl-macs)
 
 (define-obsolete-function-alias 'timeout-throttle! 'timeout-throttle "v2.0")
 (define-obsolete-function-alias 'timeout-debounce! 'timeout-debounce "v2.0")
+
+(cl-defstruct (timeout--state (:constructor timeout--state-create)
+                              (:type vector))
+  timer ;; Timer object
+  default ;; Default value to return if function is throttled or denounced.
+  args ;; Arguments to call debounced function with
+  )
 
 (defsubst timeout--eval-value (value)
   "Eval a VALUE.
@@ -71,63 +79,57 @@ symbol, return its value.  Else return itself."
         ((and (symbolp value) (boundp value)) (symbol-value value))
         (t (error "Invalid value %s" value))))
 
-(defun timeout--throttle-advice (&optional timeout)
-  "Return a function that throttles its argument function.
+(defmacro timeout--throttle-logic (func args timeout-value state)
+  "Throttle calls to (FUNC ARGS).
 
-For the meaning of TIMEOUT see `timeout-throttle'.
+For the meaning of TIMEOUT-VALUE see `timeout-throttle'.  STATE is a
+`timeout--state' struct holding the state of the throttle.
 
 When FUNC does not run because of the throttle, the result from the
-previous successful call is returned.
+previous successful call is returned."
+  `(let ((timer (timeout--state-timer ,state)))
+     (unless (timerp timer)
+       (setf (timeout--state-default ,state)
+             (apply ,func ,args))
+       (setf (timeout--state-timer ,state)
+             (run-with-timer
+              (timeout--eval-value ,timeout-value)
+              nil
+              (lambda ()
+                (cancel-timer (timeout--state-timer ,state))
+                (setf (timeout--state-timer ,state) nil))))
+       (timeout--state-default ,state))))
 
-This is intended for use as function advice."
-  (let ((throttle-timer)
-        (timeout-value (or timeout 1.0))
-        (result))
-    (lambda (orig-fn &rest args)
-      "Throttle calls to this function."
-      (progn
-        (unless (and throttle-timer (timerp throttle-timer))
-          (setq result (apply orig-fn args))
-          (setq throttle-timer
-                (run-with-timer
-                 (timeout--eval-value timeout-value) nil
-                 (lambda ()
-                   (cancel-timer throttle-timer)
-                   (setq throttle-timer nil)))))
-        result))))
+(defmacro timeout--debounce-logic (func args delay-value state)
+  "Debounce calls to (FUNC ARGS).
 
-(defun timeout--debounce-advice (&optional delay default)
-  "Return a function that debounces its argument function.
+For the meaning of DELAY-VALUE see `timeout-debounce'.  STATE is a
+`timeout--state' struct holding the state of the debounce.
 
-For the meaning of DELAY see `timeout-debounce'.
-
-The function returns immediately with value DEFAULT when called the
-first time.  On future invocations, the result from the previous call is
-returned.
-
-This is intended for use as function advice."
-  (let ((debounce-timer nil)
-        (delay-value (or delay 0.50)))
-    (lambda (orig-fn &rest args)
-      "Debounce calls to this function."
-      (prog1 default
-        (if (timerp debounce-timer)
-            (timer-set-idle-time debounce-timer (timeout--eval-value delay-value))
-          (setq debounce-timer
-                (run-with-idle-timer
-                 (timeout--eval-value delay-value) nil
-                 (lambda (buf)
-                   (cancel-timer debounce-timer)
-                   (setq debounce-timer nil)
-                   (setq default
-                         (if (buffer-live-p buf)
-                             (with-current-buffer buf
-                               (apply orig-fn args))
-                           (apply orig-fn args))))
-                 (current-buffer))))))))
+Return immediately with value DEFAULT when called the first time.  On
+future invocations, the result from the previous function call is
+returned."
+  `(prog1 (timeout--state-default ,state)
+     (setf (timeout--state-args ,state) ,args)
+     (let ((debounce-timer (timeout--state-timer ,state)))
+       (if (timerp debounce-timer)
+           (timer-set-idle-time debounce-timer
+                                (timeout--eval-value ,delay-value))
+         (setf (timeout--state-timer ,state)
+               (run-with-idle-timer
+                (timeout--eval-value ,delay-value) nil
+                (lambda (buf)
+                  (cancel-timer (timeout--state-timer ,state))
+                  (setf (timeout--state-timer ,state) nil)
+                  (setf (timeout--state-default ,state)
+                        (if (buffer-live-p buf)
+                            (with-current-buffer buf
+                              (apply ,func (timeout--state-args ,state)))
+                          (apply ,func (timeout--state-args ,state)))))
+                (current-buffer)))))))
 
 ;;;###autoload
-(defun timeout-debounce (func &optional delay default)
+(defun timeout-debounce (func &optional delay default state)
   "Debounce FUNC by making it run DELAY seconds after it is called.
 
 This advises FUNC, when called (interactively or from code), to
@@ -141,31 +143,53 @@ duration.  Using a delay of 0 removes any debounce advice.
 
 The function returns immediately with value DEFAULT when called the
 first time.  On future invocations, the result from the previous call is
-returned."
-  (if (and delay (eq delay 0))
+returned.
+
+STATE is a `timeout--state' object holding the state of the debounce.
+
+Returns the `timeout--state' object."
+  (if (and delay (zerop delay))
       (advice-remove func 'debounce)
-    (advice-add func :around (timeout--debounce-advice delay default)
-                '((name . debounce)
-                  (depth . -99)))))
+    (let ((state (or state (timeout--state-create)))
+          (delay-value (or delay 0.50)))
+      (setf (timeout--state-default state) default)
+      (advice-add func :around
+                  (lambda (orig-fn &rest args)
+                    "Debounce calls to this function."
+                    (timeout--debounce-logic orig-fn args delay-value state))
+                  `((name . debounce)
+                    (depth . -99)))
+      state)))
 
 ;;;###autoload
-(defun timeout-throttle (func &optional throttle)
+(defun timeout-throttle (func &optional throttle state)
   "Make FUNC run no more frequently than once every THROTTLE seconds.
 
-THROTTLE defaults to 1 second.  THROTTLE can be a number, a symbol (whose
-value is a number), or a function (that evaluates to a number).  When
-passed a symbol or function, it is evaluated at runtime for dynamic
-duration.  Using a throttle of 0 removes any throttle advice.
+THROTTLE defaults to 1 second.  THROTTLE can be a number, a
+symbol (whose value is a number), or a function (that evaluates to a
+number).  When passed a symbol or function, it is evaluated at runtime
+for dynamic duration.  Using a throttle of 0 removes any throttle
+advice.
 
 When FUNC does not run because of the throttle, the result from the
-previous successful call is returned."
-  (if (and throttle (eq throttle 0))
-      (advice-remove func 'throttle)
-    (advice-add func :around (timeout--throttle-advice throttle)
-                '((name . throttle)
-                  (depth . -98)))))
+previous successful call is returned.
 
-(defun timeout-throttled-func (func &optional throttle)
+STATE is a `timeout--state' object holding the state of the throttle.
+
+Return the `timeout--state' object."
+  (if (and throttle (zerop throttle))
+      (advice-remove func 'throttle)
+    (let ((state (or state (timeout--state-create)))
+          (timeout-value (or throttle 1.0)))
+      (advice-add func :around
+                  (lambda (orig-fn &rest args)
+                    "Throttle calls to this function."
+                    (timeout--throttle-logic orig-fn args timeout-value state))
+                  `((name . throttle)
+                    (depth . -98)))
+      state)))
+
+(defun timeout-throttled-func (func &optional throttle state)
   "Return a throttled version of function FUNC.
 
 The throttled function runs no more frequently than once every THROTTLE
@@ -175,47 +199,28 @@ number).  When passed a symbol or function, it is evaluated at runtime
 for dynamic duration.
 
 When FUNC does not run because of the throttle, the result from the
-previous successful call is returned."
-  (let ((throttle-timer nil)
-        (throttle-value (or throttle 1))
-        (result))
+previous successful call is returned.
+
+STATE is a `timeout--state' struct holding the state of the throttle."
+  (let ((throttle-value (or throttle 1))
+        (state (or state (timeout--state-create))))
     (if (commandp func)
         ;; INTERACTIVE version
         (lambda (&rest args)
           (:documentation
-           (concat
-            (documentation func)
-            "\n\nThrottle calls to this function"))
+           (concat (documentation func)
+                   "\n\nThrottle calls to this function"))
           (interactive (advice-eval-interactive-spec
                         (cadr (interactive-form func))))
-          (progn
-            (unless (and throttle-timer (timerp throttle-timer))
-              (setq result (apply func args))
-              (setq throttle-timer
-                    (run-with-timer
-                     (timeout--eval-value throttle-value) nil
-                     (lambda ()
-                       (cancel-timer throttle-timer)
-                       (setq throttle-timer nil)))))
-            result))
+          (timeout--throttle-logic func args throttle-value state))
       ;; NON-INTERACTIVE version
       (lambda (&rest args)
         (:documentation
-         (concat
-          (documentation func)
-          "\n\nThrottle calls to this function"))
-        (progn
-          (unless (and throttle-timer (timerp throttle-timer))
-            (setq result (apply func args))
-            (setq throttle-timer
-                  (run-with-timer
-                   (timeout--eval-value throttle-value) nil
-                   (lambda ()
-                     (cancel-timer throttle-timer)
-                     (setq throttle-timer nil)))))
-          result)))))
+         (concat (documentation func)
+                 "\n\nThrottle calls to this function"))
+        (timeout--throttle-logic func args throttle-value state)))))
 
-(defun timeout-debounced-func (func &optional delay default)
+(defun timeout-debounced-func (func &optional delay default state)
   "Return a debounced version of function FUNC.
 
 The debounced function runs DELAY seconds after it is called.  DELAY
@@ -225,54 +230,27 @@ a symbol or function, it is evaluated at runtime for dynamic duration.
 
 The function returns immediately with value DEFAULT when called the
 first time.  On future invocations, the result from the previous call is
-returned."
-  (let ((debounce-timer nil)
+returned.
+
+STATE is a `timeout--state' struct holding the state of the debounce."
+  (let ((state (or state (timeout--state-create)))
         (delay-value (or delay 0.50)))
+    (setf (timeout--state-default state) default)
     (if (commandp func)
         ;; INTERACTIVE version
         (lambda (&rest args)
           (:documentation
-           (concat
-            (documentation func)
-            "\n\nDebounce calls to this function"))
+           (concat (documentation func)
+                   "\n\nDebounce calls to this function"))
           (interactive (advice-eval-interactive-spec
                         (cadr (interactive-form func))))
-          (prog1 default
-            (if (timerp debounce-timer)
-                (timer-set-idle-time debounce-timer (timeout--eval-value delay-value))
-              (setq debounce-timer
-                    (run-with-idle-timer
-                     (timeout--eval-value delay-value) nil
-                     (lambda (buf)
-                       (cancel-timer debounce-timer)
-                       (setq debounce-timer nil)
-                       (setq default
-                             (if (buffer-live-p buf)
-                                 (with-current-buffer buf
-                                   (apply func args))
-                               (apply func args))))
-                     (current-buffer))))))
+          (timeout--debounce-logic func args delay-value state))
       ;; NON-INTERACTIVE version
       (lambda (&rest args)
         (:documentation
-         (concat
-          (documentation func)
-          "\n\nDebounce calls to this function"))
-        (prog1 default
-          (if (timerp debounce-timer)
-              (timer-set-idle-time debounce-timer (timeout--eval-value delay-value))
-            (setq debounce-timer
-                  (run-with-idle-timer
-                   (timeout--eval-value delay-value) nil
-                   (lambda (buf)
-                     (cancel-timer debounce-timer)
-                     (setq debounce-timer nil)
-                     (setq default
-                           (if (buffer-live-p buf)
-                               (with-current-buffer buf
-                                 (apply func args))
-                             (apply func args))))
-                   (current-buffer)))))))))
+         (concat (documentation func)
+                 "\n\nDebounce calls to this function"))
+        (timeout--debounce-logic func args delay-value state)))))
 
 (provide 'timeout)
 ;;; timeout.el ends here


### PR DESCRIPTION
Make timeout-debounce, timeout-throttle and their function equivalents accept a timeout--state argument where timeout state is saved including the function arguments, the timer object and the last return value.

This fixes #10 and addresses the needs of #11 (and similar). Also refactors duplicated code into common macros.

* timeout.el (timeout--state): New structure (timeout--throttle-logic, timeout--debounce-logic): New macros to factor similar logic.
(timeout-debounce, timeout-throttle, timeout-throttled-func) (timeout-debounced-func): all accept STATE argument and call the refactored macros.